### PR TITLE
ViewPropTypes compatibility layer

### DIFF
--- a/NavigationExperimental/NavigationCardStack.js
+++ b/NavigationExperimental/NavigationCardStack.js
@@ -37,7 +37,15 @@ const { PropTypes } = require('prop-types');
 import {
   StyleSheet,
   View,
+  ViewPropTypes as NewViewPropTypes,
 } from 'react-native';
+
+var ViewPropTypes;
+if (NewViewPropTypes) {
+  ViewPropTypes = NewViewPropTypes;
+} else {
+  ViewPropTypes = View.propTypes;
+}
 
 const React = require('react');
 
@@ -218,12 +226,12 @@ class NavigationCardStack extends React.PureComponent<DefaultProps, Props, void>
     /**
      * Custom style applied to the cards stack.
      */
-    style: View.propTypes.style,
+    style: ViewPropTypes.style,
 
     /**
      * Custom style applied to the scenes stack.
      */
-    scenesStyle: View.propTypes.style,
+    scenesStyle: ViewPropTypes.style,
   };
 
   static defaultProps: DefaultProps = {

--- a/NavigationExperimental/NavigationHeader.js
+++ b/NavigationExperimental/NavigationHeader.js
@@ -38,15 +38,23 @@ const NavigationHeaderTitle = require('./NavigationHeaderTitle');
 const NavigationPropTypes = require('./NavigationPropTypes');
 const { PropTypes } = require('prop-types');
 const React = require('react');
-const ReactNative = require('react-native');
 
-const {
+import {
   Animated,
   Platform,
   StyleSheet,
   TVEventHandler,
   View,
-} = ReactNative;
+  ViewPropTypes as NewViewPropTypes,
+} from 'react-native';
+
+var ViewPropTypes;
+
+if (NewViewPropTypes) {
+  ViewPropTypes = NewViewPropTypes;
+} else {
+  ViewPropTypes = View.propTypes;
+}
 
 import type  {
   NavigationSceneRendererProps,
@@ -115,9 +123,9 @@ class NavigationHeader extends React.PureComponent<DefaultProps, Props, any> {
     renderLeftComponent: PropTypes.func,
     renderRightComponent: PropTypes.func,
     renderTitleComponent: PropTypes.func,
-    style: View.propTypes.style,
+    style: ViewPropTypes.style,
     statusBarHeight: PropTypes.number,
-    viewProps: PropTypes.shape(View.propTypes),
+    viewProps: PropTypes.shape(ViewPropTypes),
   };
 
   _tvEventHandler: TVEventHandler;

--- a/NavigationExperimental/NavigationHeaderTitle.js
+++ b/NavigationExperimental/NavigationHeaderTitle.js
@@ -39,9 +39,18 @@ const ReactNative = require('react-native');
 import {
   Platform,
   StyleSheet,
-  View,
   Text,
+  View,
+  ViewPropTypes as NewViewPropTypes,
 } from 'react-native';
+
+var ViewPropTypes;
+
+if (NewViewPropTypes) {
+  ViewPropTypes = NewViewPropTypes;
+} else {
+  ViewPropTypes = View.propTypes;
+}
 
 type Props = {
   children?: React.Element<any>,
@@ -75,7 +84,7 @@ const styles = StyleSheet.create({
 
 NavigationHeaderTitle.propTypes = {
   children: PropTypes.node.isRequired,
-  style: View.propTypes.style,
+  style: ViewPropTypes.style,
   textStyle: Text.propTypes.style
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactxp-experimental-navigation",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "repository": {
     "type": "git",
     "url": "https://github.com/Microsoft/react-native-experimental-navigation"


### PR DESCRIPTION
ViewPropTypes doesn't exist in react-native 42 and View.propTypes is deprecated and causes warning in react-native 46+. This change fixes the problem.