### PR TITLE
Alter react lifecycle methods to match current deprecation

### DIFF
--- a/NavigationExperimental/NavigationCardStack.js
+++ b/NavigationExperimental/NavigationCardStack.js
@@ -243,7 +243,7 @@ class NavigationCardStack extends React.PureComponent<DefaultProps, Props, void>
     super(props, context);
   }
 
-  componentWillMount(): void {
+  UNSAFE_componentWillMount(): void {
     this._render = this._render.bind(this);
     this._renderScene = this._renderScene.bind(this);
     this._configureTransition = this._configureTransition.bind(this);

--- a/NavigationExperimental/NavigationPointerEventsContainer.js
+++ b/NavigationExperimental/NavigationPointerEventsContainer.js
@@ -69,7 +69,7 @@ function create(
       this._pointerEvents = this._computePointerEvents();
     }
 
-    componentWillMount(): void {
+    UNSAFE_componentWillMount(): void {
       this._onPositionChange = this._onPositionChange.bind(this);
       this._onComponentRef = this._onComponentRef.bind(this);
     }
@@ -82,7 +82,7 @@ function create(
       this._positionListener && this._positionListener.remove();
     }
 
-    componentWillReceiveProps(nextProps: Props): void {
+    UNSAFE_componentWillReceiveProps(nextProps: Props): void {
       this._bindPosition(nextProps);
     }
 

--- a/NavigationExperimental/NavigationTransitioner.js
+++ b/NavigationExperimental/NavigationTransitioner.js
@@ -116,7 +116,7 @@ class NavigationTransitioner extends React.Component<any, Props, State> {
     this._isMounted = false;
   }
 
-  componentWillMount(): void {
+  UNSAFE_componentWillMount(): void {
     this._onLayout = this._onLayout.bind(this);
     this._onTransitionEnd = this._onTransitionEnd.bind(this);
   }
@@ -129,7 +129,7 @@ class NavigationTransitioner extends React.Component<any, Props, State> {
     this._isMounted = false;
   }
 
-  componentWillReceiveProps(nextProps: Props): void {
+  UNSAFE_componentWillReceiveProps(nextProps: Props): void {
     const nextScenes = NavigationScenesReducer(
       this.state.scenes,
       nextProps.navigationState,


### PR DESCRIPTION
This is the result of running the approved tool for the purpose:
`npx react-codemod rename-unsafe-lifecycles` answering '.' and 'javascript with flow'

This is connected to improvement of the out-of-the-box development experience
in ReactXP TodoList sample which still uses this navigation library

https://github.com/microsoft/reactxp/pull/1214

Without this commit merged, the native app throws warnings immediately,
with it the dev experience should be completely warning free